### PR TITLE
Update to python 3.12

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -39,7 +39,7 @@ slots:
     interface: content
     content: certbot-1
     read:
-      - $SNAP/lib/python3.8/site-packages
+      - $SNAP/lib/python3.12/site-packages
 
 plugs:
   certbot-metadata:


### PR DESCRIPTION
Update to Python 3.12 since 3.8 is EOL and current installs of the plugin fail with the message below:

`The following plugins are using an outdated python version and must be updated to be compatible with Certbot 3.0.`